### PR TITLE
Fix: Harden GitHub Actions workflow permissions

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -3,6 +3,10 @@ name: 🛡️ Quality Gates
 on:
   push:
     branches: [main, develop, feature/*]
+
+permissions:
+  contents: read
+  actions: write
   pull_request:
     branches: [main, develop]
 


### PR DESCRIPTION
Set specific top-level permissions in the quality-gates.yml workflow to `contents: read` and `actions: write` to follow the principle of least privilege. This mitigates the reported infrastructure vulnerability of overly broad default permissions.